### PR TITLE
race condition while retrieving runtime metadata

### DIFF
--- a/internal/service/runtime.go
+++ b/internal/service/runtime.go
@@ -59,6 +59,8 @@ func (s *Service) setRuntimeData(spec int, runtime *metadata.Instant, rawData st
 }
 
 func (s *Service) getMetadataInstant(spec int, hash string) *metadata.Instant {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	metadataInstant, ok := metadata.RuntimeMetadata[spec]
 	if !ok {
 		raw := s.dao.RuntimeVersionRaw(spec)

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -11,18 +11,20 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"sync"
 )
 
 // Service
 type Service struct {
 	dao dao.IDao
+	mu  *sync.Mutex
 }
 
 // New new a service and return.
 func New() (s *Service) {
 	websocket.SetEndpoint(util.WSEndPoint)
 	d, dbStorage := dao.New()
-	s = &Service{dao: d}
+	s = &Service{dao: d, mu: &sync.Mutex{}}
 	s.initSubRuntimeLatest()
 	pluginRegister(dbStorage)
 	return s


### PR DESCRIPTION
# This PR resolves race condition that happens when various goroutines read/write the `RuntimeMetadata`.

After running substrate indexer for a while, runtime panic happened with the following log messages:  
<details><summary> Substrate log</summary>

```sh
INFO 09/20-14:05:23.438 /root/raw_subscan/internal/service/substrate.go:170 Block num 244374 hash 0x380aae3ad7bb560c43be9c305f8081f27f751a1c9b79d8755392475783ac17da
INFO 09/20-14:05:23.441 /root/raw_subscan/internal/service/substrate.go:170 Block num 244375 hash 0x6ae8954045630416208b6b7c2f02dd93edaeb0a1ea0c85335e20e3a4c995231a
INFO 09/20-14:05:23.471 /polka/raw_subscan/internal/service/substrate.go:170 Block num 244377 hash 0x8d0dd7c405595e211695a079bda7a85d2b1e0fd95a5c0efff6ed0470d5c4cf82
INFO 09/20-14:05:23.471 /root/raw_subscan/internal/service/substrate.go:170 Block num 244376 hash 0x37f25ad872d315ecb514e7ea13ebdab6f8df8e5e95e5dee3eb85981df1295397
fatal error: concurrent map writes

goroutine 100 [running]:
runtime.throw(0xc08f64, 0x15)
        /snap/go/8298/src/runtime/panic.go:1117 +0x72 fp=0xc000ed99a0 sp=0xc000ed9970 pc=0x439cb2
runtime.mapassign_fast64(0xb3c620, 0xc0000a4420, 0x8, 0x26cd0)
        /snap/go/8298/src/runtime/map_fast64.go:101 +0x33e fp=0xc000ed99e0 sp=0xc000ed99a0 pc=0x4149be
github.com/itering/substrate-api-rpc/metadata.Process(0xc0000983f0, 0x0)
        /root/go/pkg/mod/github.com/itering/substrate-api-rpc@v0.4.1/metadata/metadata.go:54 +0x197 fp=0xc000ed9b18 sp=0xc000ed99e0 pc=0x871f37
github.com/itering/subscan/internal/service.(*Service).getMetadataInstant(0xc0004961c0, 0x8, 0xc0006dc2d0, 0x42, 0x0)
        /root/raw_subscan/internal/service/runtime.go:68 +0xa5 fp=0xc000ed9b78 sp=0xc000ed9b18 pc=0x92e765
github.com/itering/subscan/internal/service.(*Service).CreateChainBlock(0xc0004961c0, 0x0, 0x0, 0xc0006dc2d0, 0x42, 0xc0009d8080, 0xc00219c000, 0x70, 0x8, 0x1, ...)
        /root/raw_subscan/internal/service/block.go:28 +0xf0 fp=0xc000ed9dd0 sp=0xc000ed9b78 pc=0x9296d0
github.com/itering/subscan/internal/service.(*Service).FillBlockData(0xc0004961c0, 0x0, 0x0, 0x3ba8e, 0xc000875301, 0xc0005cff20, 0xc0004a5618)
        /root/raw_subscan/internal/service/substrate.go:225 +0xb59 fp=0xc000ed9ed8 sp=0xc000ed9dd0 pc=0x930b39
github.com/itering/subscan/internal/service.(*SubscribeService).subscribeFetchBlock.func1.1(0xc0003a2120, 0x3ba8e, 0x1)
        /root/raw_subscan/internal/service/substrate.go:111 +0x53 fp=0xc000ed9f50 sp=0xc000ed9ed8 pc=0x931453
github.com/itering/subscan/internal/service.(*SubscribeService).subscribeFetchBlock.func1(0xb717c0, 0xc001221350)
        /root/raw_subscan/internal/service/substrate.go:116 +0x5d fp=0xc000ed9f80 sp=0xc000ed9f50 pc=0x9315fd
github.com/panjf2000/ants/v2.(*goWorkerWithFunc).run.func1(0xc000433290)
        /root/go/pkg/mod/github.com/panjf2000/ants/v2@v2.4.0/worker_func.go:68 +0xb0 fp=0xc000ed9fd8 sp=0xc000ed9f80 pc=0x929170
runtime.goexit()
        /snap/go/8298/src/runtime/asm_amd64.s:1371 +0x1 fp=0xc000ed9fe0 sp=0xc000ed9fd8 pc=0x4739e1
created by github.com/panjf2000/ants/v2.(*goWorkerWithFunc).run
        /root/go/pkg/mod/github.com/panjf2000/ants/v2@v2.4.0/worker_func.go:48 +0x4c

```
</details>

Actually the error happens because of global variable [`RuntimeMetadata`](https://github.com/itering/substrate-api-rpc/blob/master/metadata/metadata.go#L18) in substrate-api-rpc. 
The [`Service` struct](https://github.com/alexqrid/subscan-essentials/blob/5fd791875dcac58f600e3592939b764f9849a0ee/internal/service/service.go#L20) should have a mutex, to avoid race condition, because several goroutines can read/write to  the same variable.  
