### PR TITLE
fix: add redis password initialization for worker

### DIFF
--- a/util/mq/go-workers.go
+++ b/util/mq/go-workers.go
@@ -34,6 +34,7 @@ func (g *GoWorker) Publish(queue, class string, args interface{}) error {
 func (g *GoWorker) Init() {
 	workers.Configure(map[string]string{
 		"server":    configs.Boot.Redis.Addr,
+		"password":  configs.Boot.Redis.Password,
 		"database":  util.IntToString(configs.Boot.Redis.DbName),
 		"pool":      "30",
 		"process":   "1",


### PR DESCRIPTION
Fixed error "NOAUTH Authentication required" that occurs when workers use Azure Redis. It requires password for authentication even when using non-TLS connection on port 6379. If the password is not specified, it returns the specified error.
For the empty password the worker's workflow will not change for other platforms (like Docker) since there is a check for empty password in worker's code.